### PR TITLE
Allow zend-stratigility 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "sentry/sentry": "^1.7",
-        "zendframework/zend-stratigility": "^2.0",
+        "zendframework/zend-stratigility": "^2.0 || ^3.0",
         "zendframework/zend-servicemanager": "^3.3"
     },
     "autoload": {


### PR DESCRIPTION
We can allow zend-stratigility 3.0 since the error handling mechanisms did not change over major version. I have tested it works as expected. 
Please merge